### PR TITLE
use `--retry-all-errors` when downloading tests

### DIFF
--- a/download_test_vectors.sh
+++ b/download_test_vectors.sh
@@ -31,7 +31,7 @@ dl_version() {
 	for flavour in "${FLAVOURS[@]}"; do
 		if [[ ! -e "${flavour}.tar.gz" ]]; then
 			echo "Downloading: ${version}/${flavour}.tar.gz"
-			curl --location --remote-name --silent --show-error --retry 3 \
+			curl --location --remote-name --silent --show-error --retry 3 --retry-all-errors \
 				"https://github.com/ethereum/consensus-spec-tests/releases/download/${version}/${flavour}.tar.gz" \
 				|| {
 					echo "Curl failed. Aborting"


### PR DESCRIPTION
Some errors during test vectors download do not currently trigger retry: curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1) Setting `--retry-all-errors` should help mitigate that.