### PR TITLE
retry download on unpack error

### DIFF
--- a/download_slashing_interchange_tests.sh
+++ b/download_slashing_interchange_tests.sh
@@ -36,7 +36,7 @@ dl_version() {
 	for flavour in "${FLAVOURS[@]}"; do
 		if [[ ! -e "${flavour}.tar.gz" ]]; then
 			echo "Downloading: slashing-${version}/${flavour}.tar.gz"
-			curl --location --remote-name --silent --show-error --retry 3 --retry-all-errors \
+			curl --location --remote-name --silent --show-error --retry 3 --retry-connrefused \
 				"https://github.com/eth-clients/slashing-protection-interchange-tests/archive/refs/tags/${flavour}.tar.gz" \
 				|| {
 					echo "Curl failed. Aborting"

--- a/download_slashing_interchange_tests.sh
+++ b/download_slashing_interchange_tests.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Copyright (c) 2021-2022 Status Research & Development GmbH. Licensed under
+# either of:
+# - Apache License, version 2.0
+# - MIT license
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
 set -eu
 
 VERSIONS=(
@@ -29,7 +36,7 @@ dl_version() {
 	for flavour in "${FLAVOURS[@]}"; do
 		if [[ ! -e "${flavour}.tar.gz" ]]; then
 			echo "Downloading: slashing-${version}/${flavour}.tar.gz"
-			curl --location --remote-name --show-error \
+			curl --location --remote-name --silent --show-error --retry 3 --retry-all-errors \
 				"https://github.com/eth-clients/slashing-protection-interchange-tests/archive/refs/tags/${flavour}.tar.gz" \
 				|| {
 					echo "Curl failed. Aborting"
@@ -45,24 +52,31 @@ unpack_version() {
 	[[ -z "$1" ]] && { echo "usage: unpack_version() vX.Y.Z"; exit 1; }
 	version="$1"
 
-	dl_version "$version"
+	local retries=0 ok=0
+	while (( !ok && ++retries <= 5 )); do  # downloaded tar.gz may be corrupted
+		dl_version "$version"
 
-	# suppress warnings when unpacking with GNU tar an archive created with BSD tar (probably on macOS)
-	EXTRA_TAR_PARAMS=""
-	tar --version | grep -qi 'gnu' && EXTRA_TAR_PARAMS="--warning=no-unknown-keyword --ignore-zeros"
+		# suppress warnings when unpacking with GNU tar an archive created with BSD tar (probably on macOS)
+		EXTRA_TAR_PARAMS=""
+		tar --version | grep -qi 'gnu' && EXTRA_TAR_PARAMS="--warning=no-unknown-keyword --ignore-zeros"
 
-	if [[ ! -d "tests-slashing-${version}" ]]; then
-		for flavour in "${FLAVOURS[@]}"; do
-			echo "Unpacking: slashing-${version}/${flavour}.tar.gz"
-			mkdir -p "tests-slashing-${version}"
-			tar -C "tests-slashing-${version}" --strip-components 1 ${EXTRA_TAR_PARAMS} -xzf \
-				"tarballs/slashing-${version}/${flavour}.tar.gz" \
-				|| {
-					echo "Tar failed. Aborting."
-				  rm -rf "tests-slashing-${version}"
-					exit 1
-				}
-		done
+		ok=1
+		if [[ ! -d "tests-slashing-${version}" ]]; then
+			for flavour in "${FLAVOURS[@]}"; do
+				echo "Unpacking: slashing-${version}/${flavour}.tar.gz"
+				mkdir -p "tests-slashing-${version}"
+				tar -C "tests-slashing-${version}" --strip-components 1 ${EXTRA_TAR_PARAMS} -xzf \
+					"tarballs/slashing-${version}/${flavour}.tar.gz" \
+					|| {
+						rm -rf "tests-slashing-${version}" "tarballs/slashing-${version}/${flavour}.tar.gz"
+						ok=0
+					}
+			done
+		fi
+	done
+	if (( !ok )); then
+		echo "Unpacking failed too often. Aborting."
+		exit 1
 	fi
 }
 

--- a/download_test_vectors.sh
+++ b/download_test_vectors.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Copyright (c) 2019-2022 Status Research & Development GmbH. Licensed under
+# either of:
+# - Apache License, version 2.0
+# - MIT license
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
 set -eu
 
 VERSIONS=(
@@ -47,24 +54,31 @@ unpack_version() {
 	[[ -z "$1" ]] && { echo "usage: unpack_version() vX.Y.Z"; exit 1; }
 	version="$1"
 
-	dl_version "$version"
+	local retries=0 ok=0
+	while (( !ok && ++retries <= 5 )); do  # downloaded tar.gz may be corrupted
+		dl_version "$version"
 
-	# suppress warnings when unpacking with GNU tar an archive created with BSD tar (probably on macOS)
-	EXTRA_TAR_PARAMS=""
-	tar --version | grep -qi 'gnu' && EXTRA_TAR_PARAMS="--warning=no-unknown-keyword --ignore-zeros"
+		# suppress warnings when unpacking with GNU tar an archive created with BSD tar (probably on macOS)
+		EXTRA_TAR_PARAMS=""
+		tar --version | grep -qi 'gnu' && EXTRA_TAR_PARAMS="--warning=no-unknown-keyword --ignore-zeros"
 
-	if [[ ! -d "tests-${version}" ]]; then
-		for flavour in "${FLAVOURS[@]}"; do
-			echo "Unpacking: ${version}/${flavour}.tar.gz"
-			mkdir -p "tests-${version}"
-			tar -C "tests-${version}" --strip-components 1 ${EXTRA_TAR_PARAMS} --exclude=phase1 -xzf \
-				"tarballs/${version}/${flavour}.tar.gz" \
-				|| {
-					echo "Tar failed. Aborting."
-					rm -rf "tests-${version}"
-					exit 1
-				}
-		done
+		ok=1
+		if [[ ! -d "tests-${version}" ]]; then
+			for flavour in "${FLAVOURS[@]}"; do
+				echo "Unpacking: ${version}/${flavour}.tar.gz"
+				mkdir -p "tests-${version}"
+				tar -C "tests-${version}" --strip-components 1 ${EXTRA_TAR_PARAMS} --exclude=phase1 -xzf \
+					"tarballs/${version}/${flavour}.tar.gz" \
+					|| {
+						rm -rf "tests-${version}" "tarballs/${version}/${flavour}.tar.gz"
+						ok=0
+					}
+			done
+		fi
+	done
+	if (( !ok )); then
+		echo "Unpacking failed too often. Aborting."
+		exit 1
 	fi
 }
 

--- a/download_test_vectors.sh
+++ b/download_test_vectors.sh
@@ -38,7 +38,7 @@ dl_version() {
 	for flavour in "${FLAVOURS[@]}"; do
 		if [[ ! -e "${flavour}.tar.gz" ]]; then
 			echo "Downloading: ${version}/${flavour}.tar.gz"
-			curl --location --remote-name --silent --show-error --retry 3 --retry-all-errors \
+			curl --location --remote-name --silent --show-error --retry 3 --retry-connrefused \
 				"https://github.com/ethereum/consensus-spec-tests/releases/download/${version}/${flavour}.tar.gz" \
 				|| {
 					echo "Curl failed. Aborting"


### PR DESCRIPTION
Sometimes, the downloaded tar file gets corrupted and fails to unpack. Add a couple retries to avoid spurious CI failures in dependent projs.

```
[2022-12-09T23:17:22.588Z] + ./scripts/setup_scenarios.sh
[2022-12-09T23:17:22.588Z] Downloading consensus spec test vectors
[2022-12-09T23:17:22.588Z] ~/workspace/atforms_macos_aarch64_dev_etan_y/vendor/nim-eth2-scenarios ~/workspace/atforms_macos_aarch64_dev_etan_y
[2022-12-09T23:17:22.588Z] Downloading: v1.2.0/general.tar.gz
[2022-12-09T23:17:24.296Z] Downloading: v1.2.0/minimal.tar.gz
[2022-12-09T23:17:29.150Z] Downloading: v1.2.0/mainnet.tar.gz
[2022-12-09T23:17:30.331Z] Unpacking: v1.2.0/general.tar.gz
[2022-12-09T23:17:30.671Z] Unpacking: v1.2.0/minimal.tar.gz
[2022-12-09T23:17:36.665Z] Unpacking: v1.2.0/mainnet.tar.gz
[2022-12-09T23:17:36.665Z] tar: Error opening archive: Unrecognized archive format
[2022-12-09T23:17:36.665Z] Tar failed. Aborting.
script returned exit code 1
```