### PR TITLE
avoid spurious deletion of slashing test vectors

### DIFF
--- a/download_slashing_interchange_tests.sh
+++ b/download_slashing_interchange_tests.sh
@@ -74,7 +74,7 @@ done
 # delete tarballs and unpacked data from old versions
 for tpath in tarballs/slashing-*; do
 	tdir="$(basename "$tpath")"
-	if [[ ! " ${VERSIONS[@]} " =~ " $tdir " ]]; then
+	if [[ ! " slashing-${VERSIONS[@]} " =~ " $tdir " ]]; then
 		rm -rf "$tpath"
 	fi
 done

--- a/download_test_vectors.sh
+++ b/download_test_vectors.sh
@@ -75,7 +75,7 @@ done
 
 # delete tarballs and unpacked data from old versions
 for tpath in tarballs/*; do
-	if [[ "$tpath" =~ tarballs/slashing-* ]]; then
+	if [[ "$tpath" == tarballs/slashing-* ]]; then
 		continue  # avoid interfering with slashing interchange tests
 	fi
 	tdir="$(basename "$tpath")"
@@ -84,7 +84,7 @@ for tpath in tarballs/*; do
 	fi
 done
 for tpath in tests-*; do
-	if [[ "$tpath" =~ tests-slashing-* ]]; then
+	if [[ "$tpath" == tests-slashing-* ]]; then
 		continue  # avoid interfering with slashing interchange tests
 	fi
 	tver="$(echo "$tpath" | sed -e's/^tests-//')"

--- a/download_test_vectors.sh
+++ b/download_test_vectors.sh
@@ -75,12 +75,18 @@ done
 
 # delete tarballs and unpacked data from old versions
 for tpath in tarballs/*; do
+	if [[ "$tpath" =~ tarballs/slashing-* ]]; then
+		continue  # avoid interfering with slashing interchange tests
+	fi
 	tdir="$(basename "$tpath")"
 	if [[ ! " ${VERSIONS[@]} " =~ " $tdir " ]]; then
 		rm -rf "$tpath"
 	fi
 done
 for tpath in tests-*; do
+	if [[ "$tpath" =~ tests-slashing-* ]]; then
+		continue  # avoid interfering with slashing interchange tests
+	fi
 	tver="$(echo "$tpath" | sed -e's/^tests-//')"
 	if [[ ! " ${VERSIONS[@]} " =~ " $tver " ]]; then
 		rm -rf "$tpath"

--- a/download_test_vectors.sh
+++ b/download_test_vectors.sh
@@ -75,7 +75,7 @@ done
 
 # delete tarballs and unpacked data from old versions
 for tpath in tarballs/*; do
-	if [[ "$tpath" == tarballs/slashing-* ]]; then
+	if [[ "$tpath" == "tarballs/slashing-"* ]]; then
 		continue  # avoid interfering with slashing interchange tests
 	fi
 	tdir="$(basename "$tpath")"
@@ -84,7 +84,7 @@ for tpath in tarballs/*; do
 	fi
 done
 for tpath in tests-*; do
-	if [[ "$tpath" == tests-slashing-* ]]; then
+	if [[ "$tpath" == "tests-slashing-"* ]]; then
 		continue  # avoid interfering with slashing interchange tests
 	fi
 	tver="$(echo "$tpath" | sed -e's/^tests-//')"


### PR DESCRIPTION
Slashing tests tarball and output is deleted by unpack script even when it didn't change. Hardened the logic to avoid that.