### PR TITLE
Add support for nightly test vectors

### DIFF
--- a/download_test_vectors.sh
+++ b/download_test_vectors.sh
@@ -45,6 +45,13 @@ dl_version() {
 			exit 1
 		fi
 
+		for cmd in unzip jq; do
+			if ! command -v "${cmd}" >/dev/null 2>&1; then
+				echo "Error ${cmd} is not installed"
+				exit 1
+			fi
+		done
+
 		repo="ethereum/consensus-specs"
 		api="https://api.github.com"
 		auth_header="Authorization: token ${GITHUB_TOKEN}"

--- a/download_test_vectors.sh
+++ b/download_test_vectors.sh
@@ -78,7 +78,7 @@ dl_version() {
 				}
 
 				unzip -qo "${name}.zip"
-				rm -rf "${name}.zip"
+				rm -f "${name}.zip"
 			done
 	else
 		for flavour in "${FLAVOURS[@]}"; do

--- a/download_test_vectors.sh
+++ b/download_test_vectors.sh
@@ -9,9 +9,9 @@
 
 set -Eeuo pipefail
 
-# Override versions, eg: TEST_VECTORS_VERSIONS=nightly
-if [[ -n "${TEST_VECTORS_VERSIONS:-}" ]]; then
-	IFS=',' read -ra VERSIONS <<< "$TEST_VECTORS_VERSIONS"
+# Override versions, eg: CONSENSUS_TEST_VECTOR_VERSIONS=nightly
+if [[ -n "${CONSENSUS_TEST_VECTOR_VERSIONS:-}" ]]; then
+	IFS=',' read -ra VERSIONS <<< "$CONSENSUS_TEST_VECTOR_VERSIONS"
 else
 	VERSIONS=("v1.6.0-alpha.0")
 fi

--- a/download_test_vectors.sh
+++ b/download_test_vectors.sh
@@ -13,7 +13,7 @@ set -Eeuo pipefail
 if [[ -n "${TEST_VECTORS_VERSIONS:-}" ]]; then
 	IFS=',' read -ra VERSIONS <<< "$TEST_VECTORS_VERSIONS"
 else
-	VERSIONS=("v1.5.0-beta.5")
+	VERSIONS=("v1.6.0-alpha.0")
 fi
 FLAVOURS=(
 	"general"


### PR DESCRIPTION
I would like to run the nightly test vectors on nimbus-eth2. To do this, we must download these from [the consensus-specs action](https://github.com/ethereum/consensus-specs/actions/workflows/generate_vectors.yml). Unfortunately, this requires a `GITHUB_TOKEN` be setup and it's not quite as simple as curling a file. I've updated the script to check for a new environment variable (`CONSENSUS_TEST_VECTOR_VERSIONS`). This can be a single value or multiple (comma-delimited). If given `nightly`, it will behave differently. This is how it looks:

```
$ CONSENSUS_TEST_VECTOR_VERSIONS=nightly ./download_test_vectors.sh
Downloading nightly test vectors for run: 15152167139
Downloading artifact: General Test Configuration
######################################################################## 100.0%
Downloading artifact: Minimal Test Configuration
######################################################################## 100.0%
Downloading artifact: Mainnet Test Configuration
######################################################################## 100.0%
Unpacking: nightly/general.tar.gz
Unpacking: nightly/minimal.tar.gz
Unpacking: nightly/mainnet.tar.gz
```

PS: I also added `--progress-bar` to the existing command. Can remove these if desired, but I think it's useful.